### PR TITLE
Configure MySQL connection and add initial database schema

### DIFF
--- a/.development.env
+++ b/.development.env
@@ -1,2 +1,8 @@
 username=admin
 password=admin123
+
+username=admin
+password=reset123
+
+## Database configuration
+DATABASE_URL=mysql://root:admin@localhost:3306/nzola_gest

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -23,16 +23,23 @@ import { useCompanyInfoStore } from "./store/companyInfo-store";
 import ComingSoonPage from "./pages/building";
 import { invoke } from "@tauri-apps/api/core";
 
+const check = async () => {
+  try {
+    const res = await invoke("health_check");
+    console.log(res);
+  } catch (err) {
+    console.error("Erro:", err);
+  }
+};
+
 function App() {
   const navigate = useNavigate();
   const { initDb } = useDbStore();
   const { checkAuth } = useAuthStore();
   const fetchCompany = useCompanyInfoStore((s) => s.fetchCompany);
-
+  check();
   useEffect(() => {
     const init = async () => {
-      const response = await invoke<string>("health_check");
-      console.log(response);
       await initDb();
       await checkAuth();
       await fetchCompany();

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2370,7 +2370,9 @@ dependencies = [
 name = "nzola-gest-farmacia"
 version = "0.1.0"
 dependencies = [
+ "dotenvy",
  "log",
+ "once_cell",
  "serde",
  "serde_json",
  "sqlx",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -28,6 +28,8 @@ tauri-plugin-dialog = "2"
 tauri-plugin-fs = "2"
 tokio = { version = "1", features = ["full"] }
 sqlx = { version = "0.8", features = ["mysql", "runtime-tokio-rustls", "macros", "chrono"] }
+dotenvy = "0.15"
+once_cell = "1.19"
 
 [dependencies.tauri-plugin-sql]
 features = ["postgres", "sqlite"]

--- a/src-tauri/src/app_state.rs
+++ b/src-tauri/src/app_state.rs
@@ -1,6 +1,5 @@
 use sqlx::MySqlPool;
 
-#[derive(Clone)]
 pub struct AppState {
     pub db: MySqlPool,
 }

--- a/src-tauri/src/commands/health.rs
+++ b/src-tauri/src/commands/health.rs
@@ -2,6 +2,13 @@ use tauri::State;
 use crate::app_state::AppState;
 
 #[tauri::command]
-pub fn health_check(state: State<AppState>) -> String {
-    format!("Nzola Gest backend ativo 🚀 | DB conectado")
+pub async fn health_check(state: State<'_, AppState>) -> Result<String, String> {
+    let result = sqlx::query_scalar::<_, i64>("SELECT 1")
+        .fetch_one(&state.db)
+        .await;
+
+    match result {
+        Ok(_) => Ok("Nzola Gest backend ativo 🚀 | DB conectado ✅".to_string()),
+        Err(e) => Err(format!("DB erro ❌: {}", e)),
+    }
 }

--- a/src-tauri/src/db/mysql.rs
+++ b/src-tauri/src/db/mysql.rs
@@ -1,9 +1,8 @@
 use sqlx::{mysql::MySqlPoolOptions, MySqlPool};
 
-pub async fn connect(database_url: &str) -> MySqlPool {
+pub async fn connect(database_url: &str) -> Result<MySqlPool, sqlx::Error> {
     MySqlPoolOptions::new()
         .max_connections(5)
         .connect(database_url)
         .await
-        .expect("Falha ao conectar ao MySQL")
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,12 +3,15 @@ mod commands;
 mod db;
 mod migrations;
 
-use tauri::Manager;
 use app_state::AppState;
 use db::mysql;
+use std::env;
+use tauri::Manager;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    dotenvy::dotenv().ok();
+
     tauri::Builder::default()
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_dialog::init())
@@ -25,19 +28,18 @@ pub fn run() {
             let handle = app.handle().clone();
 
             tauri::async_runtime::block_on(async move {
-                // 🔐 depois vamos mover isso para env
-                let database_url = "mysql://root:admin@localhost/nzola_gest";
+                let database_url = env::var("DATABASE_URL").expect("DATABASE_URL não definida");
 
-                let pool = mysql::connect(database_url).await;
+                let pool = mysql::connect(&database_url)
+                    .await
+                    .expect("Falha ao conectar no MySQL");
 
                 handle.manage(AppState { db: pool });
             });
 
             Ok(())
         })
-        .invoke_handler(tauri::generate_handler![
-            commands::health::health_check
-        ])
+        .invoke_handler(tauri::generate_handler![commands::health::health_check])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/src-tauri/src/migrations/0001_init_schema.sql
+++ b/src-tauri/src/migrations/0001_init_schema.sql
@@ -1,0 +1,135 @@
+-- =========================
+-- 0001_initial_schema.sql
+-- Nzola Gest - Initial Schema
+-- =========================
+
+-- -------------------------
+-- Tabela: users
+-- -------------------------
+CREATE TABLE users (
+    id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    username VARCHAR(50) NOT NULL UNIQUE,
+    name VARCHAR(100) NOT NULL,
+    surname VARCHAR(100) NOT NULL,
+    email VARCHAR(150) NOT NULL UNIQUE,
+    password_hash VARCHAR(255) NOT NULL,
+    role ENUM('ADMIN', 'RESET', 'USER') NOT NULL DEFAULT 'USER',
+    is_active BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- -------------------------
+-- Tabela: products
+-- -------------------------
+CREATE TABLE products (
+    id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(150) NOT NULL,
+    description TEXT,
+    expiration_date DATE,
+    stock_quantity INT DEFAULT 0,
+    sale_price DECIMAL(15,2),
+    category VARCHAR(100),
+    deleted BOOLEAN DEFAULT 0,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- -------------------------
+-- Tabela: sales
+-- -------------------------
+CREATE TABLE sales (
+    id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    user_id BIGINT UNSIGNED,
+    subtotal DECIMAL(15,2),
+    discount_total DECIMAL(15,2) DEFAULT 0,
+    total DECIMAL(15,2) NOT NULL,
+    payment_method VARCHAR(50) NOT NULL,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT fk_sales_user
+      FOREIGN KEY (user_id) REFERENCES users(id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- -------------------------
+-- Tabela: sale_items
+-- -------------------------
+CREATE TABLE sale_items (
+    id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    sale_id BIGINT UNSIGNED NOT NULL,
+    product_id BIGINT UNSIGNED NOT NULL,
+    quantity INT NOT NULL,
+    unit_price DECIMAL(15,2),
+    discount_type VARCHAR(20),
+    discount_value DECIMAL(15,2) DEFAULT 0,
+    discount_amount DECIMAL(15,2) DEFAULT 0,
+    subtotal DECIMAL(15,2),
+    total DECIMAL(15,2),
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT fk_sale_items_sale
+      FOREIGN KEY (sale_id) REFERENCES sales(id),
+    CONSTRAINT fk_sale_items_product
+      FOREIGN KEY (product_id) REFERENCES products(id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- -------------------------
+-- Tabela: company
+-- -------------------------
+CREATE TABLE company (
+    id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(150) NOT NULL,
+    email VARCHAR(150) NOT NULL,
+    documentCode VARCHAR(50),
+    regime VARCHAR(50),
+    nif VARCHAR(50) NOT NULL,
+    website VARCHAR(150),
+    phone VARCHAR(50) NOT NULL,
+    tradeRegister VARCHAR(100),
+    province VARCHAR(100),
+    municipality VARCHAR(100),
+    street VARCHAR(150),
+    neighborhood VARCHAR(150),
+    building VARCHAR(150),
+    logo TEXT
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- -------------------------
+-- Usuário ADMIN inicial
+-- -------------------------
+INSERT INTO users (
+    username,
+    name,
+    surname,
+    email,
+    password_hash,
+    role,
+    is_active
+) VALUES (
+    'admin',
+    'Administrador',
+    'Sistema',
+    'admin@nzola.local',
+    '$2b$12$Q6v0Rr9j8X6YqH8vX0U4uO9ZyEJ8q1n6ZJ6zU0QKZpQ1xPz5ZzZyG',
+    'ADMIN',
+    TRUE
+);
+
+-- -------------------------
+-- Usuário de RESET / emergência
+-- -------------------------
+INSERT INTO users (
+    username,
+    name,
+    surname,
+    email,
+    password_hash,
+    role,
+    is_active
+) VALUES (
+    'reset',
+    'Reset',
+    'System',
+    'aldairandre99@gmail.com',
+    '$2b$12$0xk1KZ6QyFJY8Z8Z2LxWnOeU5mP1vZB6D9ZzYQnQJ2mY3pPZy2n2G',
+    'RESET',
+    TRUE
+);


### PR DESCRIPTION
Descrição
Adicionar suporte ao MySQL no backend Rust utilizando SQLx, com pool de conexões e configuração segura.

Objetivos
Conectar o backend a um banco MySQL
Usar pool de conexões
Preparar suporte a migrations
Tarefas

Adicionar dependência SQLx (MySQL + Tokio)

Criar módulo db/mysql.rs

Criar pool de conexões global

Configurar variável de ambiente para connection string